### PR TITLE
Add support for docker and change the database path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Created by https://www.gitignore.io/api/go
+# Edit at https://www.gitignore.io/?templates=go
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+[Bb]in/
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+# End of https://www.gitignore.io/api/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM scratch
+
+LABEL maintainer="Miguel Redmars <miguel.redmars@gmail.com>"
+
+ADD bin/wemo-homecontrol /
+
+VOLUME ["/config"]
+
+VOLUME [ "/data" ]
+
+ENV HOME /data
+
+CMD ["/wemo-homecontrol"]

--- a/main.go
+++ b/main.go
@@ -415,6 +415,9 @@ func discoverDevices(hcConfig hc.Config) error {
 			acc.Switch.On.SetValue(on)
 		}
 
+		//TODO: Change this to a external configuration
+		hcConfig.StoragePath = filepath.Join(os.Getenv("HOME"), ".homecontrol", "wemo", info.Name)
+
 		t, err := hc.NewIPTransport(hcConfig, acc.Accessory)
 		if err != nil {
 			return err

--- a/makefile
+++ b/makefile
@@ -1,0 +1,43 @@
+# Go parameters
+    GOCMD=go
+    GOBUILD=$(GOCMD) build
+    GOCLEAN=$(GOCMD) clean
+    GOTEST=$(GOCMD) test
+    GOGET=$(GOCMD) get
+    TARGET=bin
+    BINARY_NAME=wemo-homecontrol
+    
+# Docker parameters
+    DOCKERCMD=sudo docker
+    DOCKERBUILD=$(DOCKERCMD) build
+    DOCKERRUN=$(DOCKERCMD) run
+    DOCKERNAME=wemo-homecontrol
+    DOCKERVOLUMEDATA=/srv/docker/wemo-homecontrol/data
+
+    
+    all: test build
+    build: 
+		$(GOBUILD) -o $(TARGET)/$(BINARY_NAME) -v
+    test:
+		$(GOTEST) -v ./...
+    clean:
+		$(GOCLEAN)
+		rm -f $(TARGET)/$(BINARY_NAME)            
+    run:
+		$(GOBUILD) -o $(TARGET)/$(BINARY_NAME) -v ./...
+		./$(TARGET)/$(BINARY_NAME)
+    deps:
+            
+    
+    
+    # Cross compilation
+    build-docker:
+		CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -a -installsuffix cgo -o $(TARGET)/$(BINARY_NAME) -v
+	
+	#Docker container build
+    docker-build:
+		$(DOCKERBUILD) -t $(BINARY_NAME) -f Dockerfile .
+
+	#Docker run
+    docker-run:
+		$(DOCKERRUN) --name $(DOCKERNAME) --rm --network host -v $(DOCKERVOLUMEDATA):/data $(BINARY_NAME)


### PR DESCRIPTION
I have added docker support. You just need to compile with static libraries and creating the docker image. To do that you just need to:
- make build-docker -> It creates the binary with all the static libraries that can be added to a container
- make docker-build -> it creates the docker image with the binary from the previous step
- make docker-run -> it launch a container with the appropriate network to listen multicast packages, a volume for storing the database (if you don't store the database, each container will create a new one and therefore you need to register again the devices on the home app) and based on the container build on the previous step.

This will generate an around 10MB container.

Also I changed the path of the database so each device will have its own folder
And added a git ignore file.

Can you have a look and see if it works for you?. It assumes you have a working docker installation. If you have any doubt, don't hesitate to contact me.